### PR TITLE
docs: add bc package to wallSelect.sh GNU related dependencies

### DIFF
--- a/hypr/scripts/wallSelect.sh
+++ b/hypr/scripts/wallSelect.sh
@@ -24,7 +24,7 @@
 # Dependencies:
 #   → Core: hyprland, rofi, jq, xxhsum (xxhash)
 #   → Media: swww, imagemagick
-#   → GNU: findutils, coreutils
+#   → GNU: findutils, coreutils, bc
 
 
 


### PR DESCRIPTION
Added missing "bc" dependency to wallSelect.sh comments.

The script uses `bc` to calculate icon sizes, but it wasn't included in the dependencies list resulting in an error:


![2025-05-05-152839_hyprshot](https://github.com/user-attachments/assets/8fda052e-860d-4585-8db6-2e274811183f)